### PR TITLE
Revert "Fix mintegral adapter version to be compatible with 2.0.0"

### DIFF
--- a/Specs/ScaleMonkAds-AppLovinMediation/10.2.0.1/ScaleMonkAds-AppLovinMediation.podspec.json
+++ b/Specs/ScaleMonkAds-AppLovinMediation/10.2.0.1/ScaleMonkAds-AppLovinMediation.podspec.json
@@ -54,7 +54,7 @@
             "7.1.5.0.0"
         ],
         "AppLovinMediationMintegralAdapter": [
-            "6.7.6.0.0"
+            "6.9.1.0.0"
         ],
         "AppLovinMediationSmaatoAdapter": [
             "21.6.10.0"


### PR DESCRIPTION
Reverts scalemonk/ios-podspecs-framework#44