### PR TITLE
Release:  ScaleMonkAds-6.6.0-rc.2  ScaleMonkAds-AdMob-8.7.0.6.6.0-rc.2  ScaleMonkAds-AppLovin-10.3.7.6.6.0-rc.2  ScaleMonkAds-Facebook-6.9.0.6.6.0-rc.3  ScaleMonkAds-IronSource-7.1.5.0.6.6.0-rc.2  ScaleMonkAds-UnityAds-3.6.0.6.6.0-rc.2  ScaleMonkAds-Vungle-6.10.3.6.6.0-rc.2  ScaleMonkAds-Chartboost-8.4.0.6.6.0-rc.2  ScaleMonkAds-AdColony-4.3.1.6.6.0-rc.2  ScaleMonkAds-Smaato-21.6.10.6.6.0-rc.2  ScaleMonkAds-Fyber-7.8.1.6.6.0-rc.2  ScaleMonkAds-Amazon-3.2.1.6.6.0-rc.2  ScaleMonkAds-Tiktok-3.3.6.2.6.6.0-rc.2  ScaleMonkAds-Tapjoy-12.7.1.6.6.0-rc.2  ScaleMonkAds-Maio-1.5.8.6.6.0-rc.2  ScaleMonkAds-InMobi-9.1.7.6.6.0-rc.2  ScaleMonkAds-Mintegral-6.9.1.0.6.6.0-rc.2  ScaleMonkAds-MyTarget-5.10.3.6.6.0-rc.2  ScaleMonkAds-Yandex-4.4.1.6.6.0-rc.2  ScaleMonkAds-HyprMX-6.0.1.6.6.0-rc.2  ScaleMonkAds-Ogury-2.5.1.6.6.0-rc.2  ScaleMonkAds-AppLovinMediation-11.0.0.6.6.0-rc.2 

### DIFF
--- a/Specs/ScaleMonkAds-AdColony/4.3.1.6.6.0-rc.2/ScaleMonkAds-AdColony.podspec.json
+++ b/Specs/ScaleMonkAds-AdColony/4.3.1.6.6.0-rc.2/ScaleMonkAds-AdColony.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-AdColony",
+    "version": "4.3.1.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for AdColony",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-adcolony-4.3.1.6.6.0-rc.2/ScaleMonkAds-AdColony.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "AdColony": [
+            "4.3.1"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-AdColony/ScaleMonkAds-AdColony.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-AdMob/8.7.0.6.6.0-rc.2/ScaleMonkAds-AdMob.podspec.json
+++ b/Specs/ScaleMonkAds-AdMob/8.7.0.6.6.0-rc.2/ScaleMonkAds-AdMob.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-AdMob",
+    "version": "8.7.0.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for AdMob",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-admob-8.7.0.6.6.0-rc.2/ScaleMonkAds-AdMob.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "Google-Mobile-Ads-SDK": [
+            "8.7.0"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-AdMob/ScaleMonkAds-AdMob.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Amazon/3.2.1.6.6.0-rc.2/ScaleMonkAds-Amazon.podspec.json
+++ b/Specs/ScaleMonkAds-Amazon/3.2.1.6.6.0-rc.2/ScaleMonkAds-Amazon.podspec.json
@@ -1,0 +1,42 @@
+{
+    "name": "ScaleMonkAds-Amazon",
+    "version": "3.2.1.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Amazon",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-amazon-3.2.1.6.6.0-rc.2/ScaleMonkAds-Amazon.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "AmazonPublisherServicesSDK": [
+            "3.2.1"
+        ],
+        "SMAdsRenderer": [
+            "2.0.7"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Amazon/ScaleMonkAds-Amazon.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-AppLovin/10.3.7.6.6.0-rc.2/ScaleMonkAds-AppLovin.podspec.json
+++ b/Specs/ScaleMonkAds-AppLovin/10.3.7.6.6.0-rc.2/ScaleMonkAds-AppLovin.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-AppLovin",
+    "version": "10.3.7.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for AppLovin",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-applovin-10.3.7.6.6.0-rc.2/ScaleMonkAds-AppLovin.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "AppLovinSDK": [
+            "11.3.3"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-AppLovin/ScaleMonkAds-AppLovin.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-AppLovinMediation/11.0.0.6.6.0-rc.2/ScaleMonkAds-AppLovinMediation.podspec.json
+++ b/Specs/ScaleMonkAds-AppLovinMediation/11.0.0.6.6.0-rc.2/ScaleMonkAds-AppLovinMediation.podspec.json
@@ -1,0 +1,90 @@
+{
+    "name": "ScaleMonkAds-AppLovinMediation",
+    "version": "11.0.0.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for AppLovinMediation",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-applovinmediation-11.0.0.6.6.0-rc.2/ScaleMonkAds-AppLovinMediation.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "AppLovinSDK": [
+            "11.3.3"
+        ],
+        "AppLovinMediationGoogleAdapter": [
+            "8.7.0.0"
+        ],
+        "AppLovinMediationByteDanceAdapter": [
+            "3.3.6.2.1"
+        ],
+        "AppLovinMediationChartboostAdapter": [
+            "8.4.0.2"
+        ],
+        "AppLovinMediationFacebookAdapter": [
+            "6.9.0.3"
+        ],
+        "AppLovinMediationFyberAdapter": [
+            "7.8.1.0"
+        ],
+        "AppLovinMediationInMobiAdapter": [
+            "9.1.7.0"
+        ],
+        "AppLovinMediationIronSourceAdapter": [
+            "7.1.5.0.0"
+        ],
+        "AppLovinMediationMintegralAdapter": [
+            "6.9.1.0.0"
+        ],
+        "AppLovinMediationSmaatoAdapter": [
+            "21.6.10.2"
+        ],
+        "AppLovinMediationTapjoyAdapter": [
+            "12.7.1.2"
+        ],
+        "AppLovinMediationUnityAdsAdapter": [
+            "3.6.0.1"
+        ],
+        "AppLovinMediationVungleAdapter": [
+            "6.10.3.0"
+        ],
+        "AppLovinMediationMyTargetAdapter": [
+            "5.10.3.0"
+        ],
+        "AppLovinMediationMaioAdapter": [
+            "1.5.8.0"
+        ],
+        "AppLovinMediationYandexAdapter": [
+            "4.4.1.0"
+        ],
+        "AppLovinMediationHyprMXAdapter": [
+            "6.0.1.0"
+        ],
+        "AppLovinMediationOguryPresageAdapter": [
+            "2.5.1.0"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-AppLovinMediation/ScaleMonkAds-AppLovinMediation.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Chartboost/8.4.0.6.6.0-rc.2/ScaleMonkAds-Chartboost.podspec.json
+++ b/Specs/ScaleMonkAds-Chartboost/8.4.0.6.6.0-rc.2/ScaleMonkAds-Chartboost.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Chartboost",
+    "version": "8.4.0.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Chartboost",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-chartboost-8.4.0.6.6.0-rc.2/ScaleMonkAds-Chartboost.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "ChartboostSDK": [
+            "8.4.0"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Chartboost/ScaleMonkAds-Chartboost.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Facebook/6.9.0.6.6.0-rc.3/ScaleMonkAds-Facebook.podspec.json
+++ b/Specs/ScaleMonkAds-Facebook/6.9.0.6.6.0-rc.3/ScaleMonkAds-Facebook.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Facebook",
+    "version": "6.9.0.6.6.0-rc.3",
+    "summary": "ScaleMonk Mediation Adapter for Facebook",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-facebook-6.9.0.6.6.0-rc.3/ScaleMonkAds-Facebook.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "FBAudienceNetwork": [
+            "6.9.0"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Facebook/ScaleMonkAds-Facebook.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Fyber/7.8.1.6.6.0-rc.2/ScaleMonkAds-Fyber.podspec.json
+++ b/Specs/ScaleMonkAds-Fyber/7.8.1.6.6.0-rc.2/ScaleMonkAds-Fyber.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Fyber",
+    "version": "7.8.1.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Fyber",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-fyber-7.8.1.6.6.0-rc.2/ScaleMonkAds-Fyber.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "Fyber_Marketplace_SDK": [
+            "7.8.1"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Fyber/ScaleMonkAds-Fyber.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-HyprMX/6.0.1.6.6.0-rc.2/ScaleMonkAds-HyprMX.podspec.json
+++ b/Specs/ScaleMonkAds-HyprMX/6.0.1.6.6.0-rc.2/ScaleMonkAds-HyprMX.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-HyprMX",
+    "version": "6.0.1.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for HyprMX",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-hyprmx-6.0.1.6.6.0-rc.2/ScaleMonkAds-HyprMX.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "HyprMX": [
+            "6.0.1"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-HyprMX/ScaleMonkAds-HyprMX.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-InMobi/9.1.7.6.6.0-rc.2/ScaleMonkAds-InMobi.podspec.json
+++ b/Specs/ScaleMonkAds-InMobi/9.1.7.6.6.0-rc.2/ScaleMonkAds-InMobi.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-InMobi",
+    "version": "9.1.7.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for InMobi",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-inmobi-9.1.7.6.6.0-rc.2/ScaleMonkAds-InMobi.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "InMobiSDK/Core": [
+            "9.1.7"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-InMobi/ScaleMonkAds-InMobi.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-IronSource/7.1.5.0.6.6.0-rc.2/ScaleMonkAds-IronSource.podspec.json
+++ b/Specs/ScaleMonkAds-IronSource/7.1.5.0.6.6.0-rc.2/ScaleMonkAds-IronSource.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-IronSource",
+    "version": "7.1.5.0.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for IronSource",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-ironsource-7.1.5.0.6.6.0-rc.2/ScaleMonkAds-IronSource.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "IronSourceSDK": [
+            "7.1.5.0"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-IronSource/ScaleMonkAds-IronSource.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Maio/1.5.8.6.6.0-rc.2/ScaleMonkAds-Maio.podspec.json
+++ b/Specs/ScaleMonkAds-Maio/1.5.8.6.6.0-rc.2/ScaleMonkAds-Maio.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Maio",
+    "version": "1.5.8.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Maio",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-maio-1.5.8.6.6.0-rc.2/ScaleMonkAds-Maio.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "MaioSDK": [
+            "1.5.8"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Maio/ScaleMonkAds-Maio.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Mintegral/6.9.1.0.6.6.0-rc.2/ScaleMonkAds-Mintegral.podspec.json
+++ b/Specs/ScaleMonkAds-Mintegral/6.9.1.0.6.6.0-rc.2/ScaleMonkAds-Mintegral.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Mintegral",
+    "version": "6.9.1.0.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Mintegral",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-mintegral-6.9.1.0.6.6.0-rc.2/ScaleMonkAds-Mintegral.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "MintegralAdSDK": [
+            "6.9.1.0"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Mintegral/ScaleMonkAds-Mintegral.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-MyTarget/5.10.3.6.6.0-rc.2/ScaleMonkAds-MyTarget.podspec.json
+++ b/Specs/ScaleMonkAds-MyTarget/5.10.3.6.6.0-rc.2/ScaleMonkAds-MyTarget.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-MyTarget",
+    "version": "5.10.3.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for MyTarget",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-mytarget-5.10.3.6.6.0-rc.2/ScaleMonkAds-MyTarget.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "myTargetSDK": [
+            "5.10.3"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-MyTarget/ScaleMonkAds-MyTarget.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Ogury/2.5.1.6.6.0-rc.2/ScaleMonkAds-Ogury.podspec.json
+++ b/Specs/ScaleMonkAds-Ogury/2.5.1.6.6.0-rc.2/ScaleMonkAds-Ogury.podspec.json
@@ -1,0 +1,42 @@
+{
+    "name": "ScaleMonkAds-Ogury",
+    "version": "2.5.1.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Ogury",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-ogury-2.5.1.6.6.0-rc.2/ScaleMonkAds-Ogury.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "OguryAds": [
+            "2.5.1"
+        ],
+        "OguryChoiceManager": [
+            "3.1.8"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Ogury/ScaleMonkAds-Ogury.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Smaato/21.6.10.6.6.0-rc.2/ScaleMonkAds-Smaato.podspec.json
+++ b/Specs/ScaleMonkAds-Smaato/21.6.10.6.6.0-rc.2/ScaleMonkAds-Smaato.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Smaato",
+    "version": "21.6.10.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Smaato",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-smaato-21.6.10.6.6.0-rc.2/ScaleMonkAds-Smaato.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "smaato-ios-sdk": [
+            "21.6.10"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Smaato/ScaleMonkAds-Smaato.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Tapjoy/12.7.1.6.6.0-rc.2/ScaleMonkAds-Tapjoy.podspec.json
+++ b/Specs/ScaleMonkAds-Tapjoy/12.7.1.6.6.0-rc.2/ScaleMonkAds-Tapjoy.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Tapjoy",
+    "version": "12.7.1.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Tapjoy",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-tapjoy-12.7.1.6.6.0-rc.2/ScaleMonkAds-Tapjoy.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "TapjoySDK": [
+            "12.7.1"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Tapjoy/ScaleMonkAds-Tapjoy.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Tiktok/3.3.6.2.6.6.0-rc.2/ScaleMonkAds-Tiktok.podspec.json
+++ b/Specs/ScaleMonkAds-Tiktok/3.3.6.2.6.6.0-rc.2/ScaleMonkAds-Tiktok.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Tiktok",
+    "version": "3.3.6.2.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Tiktok",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-tiktok-3.3.6.2.6.6.0-rc.2/ScaleMonkAds-Tiktok.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "Bytedance-UnionAD": [
+            "3.3.6.2"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Tiktok/ScaleMonkAds-Tiktok.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-UnityAds/3.6.0.6.6.0-rc.2/ScaleMonkAds-UnityAds.podspec.json
+++ b/Specs/ScaleMonkAds-UnityAds/3.6.0.6.6.0-rc.2/ScaleMonkAds-UnityAds.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-UnityAds",
+    "version": "3.6.0.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for UnityAds",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-unityads-3.6.0.6.6.0-rc.2/ScaleMonkAds-UnityAds.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "ScaleMonkAds": [
+            "~> 6"
+        ],
+        "UnityAds": [
+            "3.6.0"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-UnityAds/ScaleMonkAds-UnityAds.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Vungle/6.10.3.6.6.0-rc.2/ScaleMonkAds-Vungle.podspec.json
+++ b/Specs/ScaleMonkAds-Vungle/6.10.3.6.6.0-rc.2/ScaleMonkAds-Vungle.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Vungle",
+    "version": "6.10.3.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Vungle",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-vungle-6.10.3.6.6.0-rc.2/ScaleMonkAds-Vungle.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "VungleSDK-iOS": [
+            "6.10.3"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Vungle/ScaleMonkAds-Vungle.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds-Yandex/4.4.1.6.6.0-rc.2/ScaleMonkAds-Yandex.podspec.json
+++ b/Specs/ScaleMonkAds-Yandex/4.4.1.6.6.0-rc.2/ScaleMonkAds-Yandex.podspec.json
@@ -1,0 +1,39 @@
+{
+    "name": "ScaleMonkAds-Yandex",
+    "version": "4.4.1.6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation Adapter for Yandex",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-yandex-4.4.1.6.6.0-rc.2/ScaleMonkAds-Yandex.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "YandexMobileAds": [
+            "4.4.1"
+        ],
+        "ScaleMonkAds": [
+            "~> 6"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds-Yandex/ScaleMonkAds-Yandex.xcframework",
+    "swift_version": "5.1"
+}

--- a/Specs/ScaleMonkAds/6.6.0-rc.2/ScaleMonkAds.podspec.json
+++ b/Specs/ScaleMonkAds/6.6.0-rc.2/ScaleMonkAds.podspec.json
@@ -1,0 +1,48 @@
+{
+    "name": "ScaleMonkAds",
+    "version": "6.6.0-rc.2",
+    "summary": "ScaleMonk Mediation for iOS",
+    "homepage": "https://www.scalemonk.com",
+    "license": "https://www.scalemonk.com/legal/en-US/mediation-license-agreement/index.html",
+    "authors": {
+        "ScaleMonk": "mediation@scalemonk.com"
+    },
+    "source": {
+        "http": "https://github.com/scalemonk/ios-podspecs-framework/releases/download/scalemonkads-6.6.0-rc.2/ScaleMonkAds.zip"
+    },
+    "swift_versions": "5.1",
+    "platforms": {
+        "ios": "10.0"
+    },
+    "requires_arc": true,
+    "pod_target_xcconfig": {
+        "BUILD_LIBRARY_FOR_DISTRIBUTION": "YES"
+    },
+    "frameworks": [
+        "iAd",
+        "WebKit",
+        "CoreTelephony",
+        "SystemConfiguration",
+        "AdSupport"
+    ],
+    "dependencies": {
+        "RxSwift": [
+            "~> 5"
+        ],
+        "SMAnalytics": [
+            "~> 0.4"
+        ],
+        "SMDeviceInfo": [
+            "~> 0.1"
+        ],
+        "SMAdsRenderer": [
+            "~> 2.0"
+        ],
+        "Willow": [
+            "~> 5.0"
+        ]
+    },
+    "static_framework": true,
+    "vendored_frameworks": "ScaleMonkAds/ScaleMonkAds.xcframework",
+    "swift_version": "5.1"
+}


### PR DESCRIPTION
Release:  ScaleMonkAds-6.6.0-rc.2  ScaleMonkAds-AdMob-8.7.0.6.6.0-rc.2  ScaleMonkAds-AppLovin-10.3.7.6.6.0-rc.2  ScaleMonkAds-Facebook-6.9.0.6.6.0-rc.3  ScaleMonkAds-IronSource-7.1.5.0.6.6.0-rc.2  ScaleMonkAds-UnityAds-3.6.0.6.6.0-rc.2  ScaleMonkAds-Vungle-6.10.3.6.6.0-rc.2  ScaleMonkAds-Chartboost-8.4.0.6.6.0-rc.2  ScaleMonkAds-AdColony-4.3.1.6.6.0-rc.2  ScaleMonkAds-Smaato-21.6.10.6.6.0-rc.2  ScaleMonkAds-Fyber-7.8.1.6.6.0-rc.2  ScaleMonkAds-Amazon-3.2.1.6.6.0-rc.2  ScaleMonkAds-Tiktok-3.3.6.2.6.6.0-rc.2  ScaleMonkAds-Tapjoy-12.7.1.6.6.0-rc.2  ScaleMonkAds-Maio-1.5.8.6.6.0-rc.2  ScaleMonkAds-InMobi-9.1.7.6.6.0-rc.2  ScaleMonkAds-Mintegral-6.9.1.0.6.6.0-rc.2  ScaleMonkAds-MyTarget-5.10.3.6.6.0-rc.2  ScaleMonkAds-Yandex-4.4.1.6.6.0-rc.2  ScaleMonkAds-HyprMX-6.0.1.6.6.0-rc.2  ScaleMonkAds-Ogury-2.5.1.6.6.0-rc.2  ScaleMonkAds-AppLovinMediation-11.0.0.6.6.0-rc.2 